### PR TITLE
#162339299 Built out REST Endpoints for interventions (CRUD)

### DIFF
--- a/server/controllers/incidentRecord.js
+++ b/server/controllers/incidentRecord.js
@@ -43,6 +43,16 @@ export class Incidents {
     Helpers.getAllRecordsType(req, res, "red-flag");
   }
 
+  /**
+   * Returns all intervention records
+   * @param  {object} req - Contains the body of the request.
+   * @param {object} res - Contains the returned response.
+   * @return {undefined}
+   */
+  getAllInterventionRecords(req, res) {
+    Helpers.getAllRecordsType(req, res, "intervention");
+  }
+
 
   /**
    * Updates a specific redflag record's location
@@ -63,6 +73,30 @@ export class Incidents {
       requestBodyPropertyValue: location,
       statusCode : 200,
       message: "Updated red-flag record's location"
+    };
+
+    Helpers.updateSpecificRecord(req, res, updateArgumentObject);
+  }
+
+  /**
+   * Updates a specific intervention record's location
+   * @param  { object } req - Contains the body of the request.
+   * @param { object } res - Contains the returned response.
+   * @return {undefined}
+   */
+  updateInterventionLocation(req, res) {
+    const { location } = req.body;
+    const recordId = req.params.id;
+    const userId = req.userInfo.id;
+
+    const updateArgumentObject = {
+      tableName: "incidents",
+      recordId,
+      userId,
+      requestBodyPropertyName: "location",
+      requestBodyPropertyValue: location,
+      statusCode: 200,
+      message: "Updated Intervention record's location"
     };
 
     Helpers.updateSpecificRecord(req, res, updateArgumentObject);
@@ -92,6 +126,30 @@ export class Incidents {
     Helpers.updateSpecificRecord(req, res, updateArgumentObject);
   }
 
+  /**
+   * Update a specific intervention record's comment
+   * @param  {object} req - Contains the body of the request.
+   * @param {object} res - Contains the returned response.
+   * @return {undefined}
+   */
+  updateInterventionRecordComment(req, res) {
+    const { comment } = req.body;
+    const recordId = req.params.id;
+    const userId = req.userInfo.id;
+
+    const updateArgumentObject = {
+      tableName: "incidents",
+      recordId,
+      userId,
+      requestBodyPropertyName: "comment",
+      requestBodyPropertyValue: comment,
+      statusCode: 200,
+      message: "Updated Intervention record's comment"
+    };
+
+    Helpers.updateSpecificRecord(req, res, updateArgumentObject);
+  }
+
 
 
   /**
@@ -108,7 +166,7 @@ export class Incidents {
     db.any("SELECT * FROM users WHERE id = $1", [userId])
       .then((data) => {
         if (data.length < 1) {
-          return Helpers.returnForError(req, res, 404, "user not found");
+          return Helpers.returnForError(req, res, 404, "admin not found");
         } else if (data[0].isadmin !== true) {
           return Helpers.returnForError(req, res, 401, "not an admin"); }
 
@@ -120,20 +178,46 @@ export class Incidents {
               db.any("UPDATE incidents SET status = $1 WHERE id = $2 RETURNING *", [status, incidentsId])
                 .then((updatedData) => {
                   const updatedRecordId = updatedData[0].id;
-                  Helpers.returnForSuccess(req, res, 200, updatedRecordId, "record's status updated");
-                }); }
+                  if (updatedData[0].type === "red-flag") {
+                    Helpers.returnForSuccess(req, res, 200, updatedRecordId, "red-flag record's status updated");
+                  } else {
+                    Helpers.returnForSuccess(req, res, 200, updatedRecordId, "intervention record's status updated");
+                  }
+                });
+            }
           });
       });
   }
 
-
   /**
-   * Delete a specific redflag record's comment
+   * Delete a specific Intervention record
    * @param  {object} req - Contains the body of the request.
    * @param {object} res - Contains the returned response.
    * @return {undefined}
    */
-  deleteRedflagRecordRecord(req, res) {
+  deleteInterventionRecord(req, res) {
+    const recordId = req.params.id;
+    const userId = req.userInfo.id;
+
+    const deleteArgumentObject = {
+      tableName: "incidents",
+      recordId,
+      userId,
+      statusCode: 200,
+      message: "Intervention record has been deleted"
+    };
+
+    Helpers.deleteSpecificRecord(req, res, deleteArgumentObject);
+  }
+
+
+  /**
+   * Delete a specific redflag record
+   * @param  {object} req - Contains the body of the request.
+   * @param {object} res - Contains the returned response.
+   * @return {undefined}
+   */
+  deleteRedflagRecord(req, res) {
     const recordId = req.params.id;
     const userId = req.userInfo.id;
 
@@ -150,12 +234,12 @@ export class Incidents {
 
 
   /**
-   * Returns a redflag records
+   * Returns specific records
    * @param  {object} req - Contains the body of the request.
    * @param {object} res - Contains the returned response.
    * @return {undefined}
    */
-  getSpecificRedFlagRecord(req, res) {
+  getSpecificRecord(req, res) {
     const id = req.params.id;
     Helpers.getSpecificRecord(req, res, id);
   }

--- a/server/middlewares/validateGetRecords.js
+++ b/server/middlewares/validateGetRecords.js
@@ -15,6 +15,17 @@ export class GetValidator {
     Helpers.doesRecordTypeExist(req, res, "red-flag", next);
   }
 
+  /**
+   * Checks if any intervention record is found in the database
+   * @param  {object} req - Contains the body of the request.
+   * @param {object} res - Contains the returned response.
+   * @param  {next} - Proceeds to the next method on the route
+   * @return {undefined}
+   */
+  static doesInterventionRecordExist(req, res, next) {
+    Helpers.doesRecordTypeExist(req, res, "intervention", next);
+  }
+
 }
 
 

--- a/server/middlewares/validatePostRecords.js
+++ b/server/middlewares/validatePostRecords.js
@@ -129,9 +129,9 @@ export class PostValidator {
    * @param  {next} - Proceeds to the next method on the route
    * @return {undefined}
    */
-  static isRedFlag(req, res, next) {
+  static isValidIncidentType(req, res, next) {
     const { type } = req.body;
-    if (type.toLowerCase() !== "red-flag") {
+    if (type.toLowerCase() !== "red-flag" && type.toLowerCase() !== "intervention") {
       Helpers.returnForError(req, res, 400, "invalid incident type");
     } else {
       next();

--- a/server/routes/interventionRoutes.js
+++ b/server/routes/interventionRoutes.js
@@ -1,33 +1,69 @@
 import express from "express";
-// import { Helpers } from "../helpers";
-// import { Incidents } from "../controllers";
-// import { PostValidator } from "../middlewares";
+import { Helpers } from "../helpers";
+import { Incidents } from "../controllers";
+import { PostValidator, GetValidator } from "../middlewares";
 
-// const incident = new Incidents();
+const incident = new Incidents();
 
 const interventionRoutes = express.Router();
 
 
 /**Create an intervention record */
-interventionRoutes.post("/interventions");
+interventionRoutes.post(
+  "/interventions",
+  Helpers.verifyUsersToken,
+  PostValidator.multipleStringValidation,
+  PostValidator.validateArrayValues,
+  PostValidator.isValidIncidentType,
+  Helpers.isNotAValidGeolocation,
+  incident.createAnIncidentRecord
+);
 
 /**Fetch all intervention records */
-interventionRoutes.get("/interventions");
+interventionRoutes.get(
+  "/interventions",
+  Helpers.verifyUsersToken,
+  GetValidator.doesInterventionRecordExist,
+  incident.getAllInterventionRecords);
 
 /**Fetch specific intervention record */
-interventionRoutes.get("/interventions/:id");
+interventionRoutes.get(
+  "/interventions/:id",
+  Helpers.verifyUsersToken,
+  incident.getSpecificRecord
+);
 
 /**Update an intervention record location*/
-interventionRoutes.patch("/interventions/:id/location");
+interventionRoutes.patch(
+  "/interventions/:id/location",
+  Helpers.verifyUsersToken,
+  PostValidator.locationStringValidation,
+  Helpers.isNotAValidGeolocation,
+  incident.updateInterventionLocation
+);
 
 /**Update an intervention record comment*/
-interventionRoutes.patch("/interventions/:id/comment");
+interventionRoutes.patch(
+  "/interventions/:id/comment",
+  Helpers.verifyUsersToken,
+  PostValidator.commentStringValidation,
+  incident.updateInterventionRecordComment
+);
 
 /**Delete an intervention record */
-interventionRoutes.delete("/interventions/:id");
+interventionRoutes.delete(
+  "/interventions/:id",
+  Helpers.verifyUsersToken,
+  incident.deleteInterventionRecord
+);
 
-/**Update an intervebtion record status*/
-interventionRoutes.patch("/interventions/:id/status");
+/**Update an intervention record status*/
+interventionRoutes.patch(
+  "/interventions/:id/status",
+  Helpers.verifyUsersToken,
+  PostValidator.validateStatus,
+  incident.updateIncidentsStatus
+);
 
 
 export default interventionRoutes;

--- a/server/routes/redFlagRoutes.js
+++ b/server/routes/redFlagRoutes.js
@@ -13,7 +13,7 @@ redFlagRoutes.post(
   Helpers.verifyUsersToken,
   PostValidator.multipleStringValidation,
   PostValidator.validateArrayValues,
-  PostValidator.isRedFlag,
+  PostValidator.isValidIncidentType,
   Helpers.isNotAValidGeolocation,
   incident.createAnIncidentRecord
 );
@@ -30,7 +30,7 @@ redFlagRoutes.get(
 redFlagRoutes.get(
   "/red-flags/:id",
   Helpers.verifyUsersToken,
-  incident.getSpecificRedFlagRecord
+  incident.getSpecificRecord
 );
 
 /**Update a red-flag record location*/
@@ -54,7 +54,7 @@ redFlagRoutes.patch(
 redFlagRoutes.delete(
   "/red-flags/:id",
   Helpers.verifyUsersToken,
-  incident.deleteRedflagRecordRecord
+  incident.deleteRedflagRecord
 );
 
 /**Update a red-flag record status*/

--- a/test/testCreateIncidentRecord.js
+++ b/test/testCreateIncidentRecord.js
@@ -11,6 +11,7 @@ dotenv.load();
 const request = supertest.agent(app);
 
 const red_flags = "/api/v1/red-flags";
+const interventions = "/api/v1/interventions";
 const geo_location = "12.233334, 2.323123";
 
 export let validToken;
@@ -20,9 +21,9 @@ const newValidToken = process.env.VALID_TOKEN;
 
 
 /**
- * Create red-flag record
+ * Create Incident record
  */
-describe("Create red-flag record end-point", () => {
+describe("Create Incident record end-point", () => {
 
   before((done) => {
     chai.request(app)
@@ -112,6 +113,34 @@ describe("Create red-flag record end-point", () => {
       });
   });
 
+  it("should return 201 if all input fields are validated correctly", (done) => {
+    request.post(interventions)
+      .set("authorization", validToken)
+      .send({
+        "title": "This is an intervention report",
+        "type": "intervention",
+        "location": geo_location,
+        "images": [
+          "evidenceImage",
+          "imageURL2"],
+        "videos": [
+          "evidenceVideo",
+          "videoURL2"],
+        "comment": "This is a report on... To be continued"
+      }).end((err, res) => {
+        expect(res.status).to.eql(201);
+        expect(res.body.data[0].message).to.eql("Created intervention record");
+        expect(res.body.data[0].message).to.be.a("string");
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        (res.body).should.be.an("object");
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+
   it("should return 201 if all input fields are validated and their are no video or image links", (done) => {
     request.post(red_flags)
       .set("authorization", validToken)
@@ -141,7 +170,7 @@ describe("Create red-flag record end-point", () => {
       .set("authorization", validToken)
       .send({
         "title": "Theft",
-        "type": "intervention",
+        "type": "intervenx",
         "location": geo_location,
         "images": [
           "imageURL1",

--- a/test/testDeleteIncidentRecord.js
+++ b/test/testDeleteIncidentRecord.js
@@ -6,11 +6,14 @@ import "chai/register-should";
 const should = chai.should();
 import chaiHttp from "chai-http";
 
+import { validToken } from "./testCreateIncidentRecord";
+
 chai.use(chaiHttp);
 
 const request = supertest.agent(app);
 
 const red_flags = "/api/v1/red-flags";
+const interventions = "/api/v1/interventions";
 const URI1 = 2;
 const URI2 = 3;
 
@@ -27,6 +30,42 @@ describe("DELETE a specific red-flag record endpoint", () => {
         expect(res.body.data[0].id).to.eql(`${URI1}`);
         expect(res.body.status).to.eql(200);
         expect(res.body.data[0].message).to.eql("red-flag record has been deleted");
+        expect(res.body.status).to.be.a("number");
+        (res.body.data[0]).should.be.an("object");
+        should.not.exist(err);
+        should.exist(res.body);
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+  it("should return 404 is updated record has been deleted", (done) => {
+    request.patch("/api/v1/red-flags/2/location")
+      .set("authorization", process.env.VALID_TOKEN)
+      .send({
+        location: "11.21134, -7.2123",
+      }).end((err, res) => {
+        expect(res.status).to.eql(404);
+        expect(res.body.error).to.eql("record not found");
+        expect(res.body.error).to.be.a("string");
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        (res.body).should.be.an("object");
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+  it("should return status 200 if specified red-flag record has been deleted", (done) => {
+    request
+      .delete(`${interventions}/${4}`)
+      .set("authorization", validToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.data[0].id).to.eql(`${4}`);
+        expect(res.body.status).to.eql(200);
+        expect(res.body.data[0].message).to.eql("Intervention record has been deleted");
         expect(res.body.status).to.be.a("number");
         (res.body.data[0]).should.be.an("object");
         should.not.exist(err);
@@ -74,6 +113,22 @@ describe("DELETE a specific red-flag record endpoint", () => {
 });
 
 
-
+describe("GET all intervention records endpoint", () => {
+  it("should return status 404 if an intervention doesn't records exist in the database", (done) => {
+    request
+      .get(interventions)
+      .set("authorization", process.env.VALID_TOKEN)
+      .end((err, res) => {
+        expect(res.status).to.eql(404);
+        expect(res.body.status).to.eql(404);
+        expect(res.body.error).to.eql("records not found");
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        if (err) { return done(err); }
+        done();
+      });
+  });
+});
 
 

--- a/test/testGetIncidentRecord.js
+++ b/test/testGetIncidentRecord.js
@@ -11,6 +11,7 @@ const validToken = process.env.VALID_TOKEN;
 
 const rootFile = "/";
 const red_flags = "/api/v1/red-flags";
+const interventions = "/api/v1/interventions";
 const validURI = 1;
 const invalidURI = 1000000;
 
@@ -41,6 +42,26 @@ describe("GET all red-flag records endpoint", () => {
   it("should return status 200 if red-flag records exist in the database", (done) => {
     request
       .get(red_flags)
+      .set("authorization", validToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.status).to.eql(200);
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        (res.body.data[0]).should.be.an("object");
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+});
+
+describe("GET all intervention records endpoint", () => {
+
+  it("should return status 200 if intervention records exist in the database", (done) => {
+    request
+      .get(interventions)
       .set("authorization", validToken)
       .end((err, res) => {
         expect(res.status).to.eql(200);

--- a/test/testUpdateIncidentRecord.js
+++ b/test/testUpdateIncidentRecord.js
@@ -117,6 +117,26 @@ describe("Update red flag location end-point", () => {
       });
   });
 
+
+  it("should return 200 if intervention record's location is updated", (done) => {
+    request.patch("/api/v1/interventions/4/location")
+      .set("authorization", validToken)
+      .send({
+        location: "11.21134, -7.2123",
+      }).end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.data[0].message).to.eql("Updated Intervention record's location");
+        expect(res.body.data[0].message).to.be.a("string");
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        (res.body).should.be.an("object");
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+
   it("should return 200 if location is updated successfully", (done) => {
     request.patch(`/api/v1/red-flags/${1}/location`)
       .set("authorization", newValidToken)
@@ -142,9 +162,9 @@ describe("Update red flag location end-point", () => {
 
 
 /**
- * Update red flag comment
+ * Update red flag and intervention comment
  */
-describe("Update red flag comment end-point", () => {
+describe("Update comment end-point", () => {
 
   it("should return 403 if the paramId doesn't match the userId of the user in the database", (done) => {
     request.patch(`/api/v1/red-flags/${3}/comment`)
@@ -164,6 +184,26 @@ describe("Update red flag comment end-point", () => {
       });
   });
 
+
+  it("should return 200 if intervention record's comment is updated", (done) => {
+    request.patch("/api/v1/interventions/4/comment")
+      .set("authorization", validToken)
+      .send({
+        comment: "i just change this intervention record",
+      }).end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.data[0].message).to.eql("Updated Intervention record's comment");
+        expect(res.body.data[0].message).to.be.a("string");
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        (res.body).should.be.an("object");
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+
   it("should return 200 if comment updates successfully", (done) => {
     request.patch(`/api/v1/red-flags/${1}/comment`)
       .set("authorization", newValidToken)
@@ -181,6 +221,7 @@ describe("Update red flag comment end-point", () => {
         done();
       });
   });
+
 
   it("should return 400 if comment is undefined", (done) => {
     request.patch(`/api/v1/red-flags/${1}/comment`)
@@ -308,8 +349,6 @@ describe("Update user profile image end-point", () => {
 
 
 
-
-
 /**
  * Update user status by Admin
  */
@@ -322,8 +361,44 @@ describe("Update status of an incident", () => {
         status: "resolved",
       }).end((err, res) => {
         expect(res.status).to.eql(200);
-        expect(res.body.data[0].message).to.eql("record's status updated");
+        expect(res.body.data[0].message).to.eql("red-flag record's status updated");
         expect(res.body.data[0].message).to.be.a("string");
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        (res.body).should.be.an("object");
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+  it("should return 200 if status updates successfully", (done) => {
+    request.patch(`/api/v1/interventions/${4}/status`)
+      .set("authorization", process.env.VALID_TOKEN)
+      .send({
+        status: "resolved",
+      }).end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.data[0].message).to.eql("intervention record's status updated");
+        expect(res.body.data[0].message).to.be.a("string");
+        expect(res.body.status).to.be.a("number");
+        should.not.exist(err);
+        should.exist(res.body);
+        (res.body).should.be.an("object");
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
+  it("should return 404 if admin is not found", (done) => {
+    request.patch(`/api/v1/interventions/${4}/status`)
+      .set("authorization", process.env.INVALID_ADMIN_TOKEN)
+      .send({
+        status: "resolved",
+      }).end((err, res) => {
+        expect(res.status).to.eql(404);
+        expect(res.body.error).to.eql("admin not found");
+        expect(res.body.error).to.be.a("string");
         expect(res.body.status).to.be.a("number");
         should.not.exist(err);
         should.exist(res.body);


### PR DESCRIPTION
#### What does this PR do?
Have CRUD on intervention endpoint in iReporter REST API

#### Description of Task to be completed?
Having the following endpoints working:
* POST `host:port/api/v1/interventions`
* GET `host:port/api/v1/interventions`
* GET `host:port/api/v1/interventions/:id`
* PATCH `host:port/api/v1/interventions/:id/location`
* PATCH `host:port/api/v1/interventions/:id/comment`
* PATCH `host:port/api/v1/interventions/:id/status`
* DELETE `host:port/api/v1/interventions/:id`

#### How should this be manually tested?
After cloning the repo, cd into it and RUN npm test
* Using Postman test every endpoint above with this header:
_key_: Content-Type value: application/json

* To test authentication, add this to the header: Get TOKEN from login endpoint
_key_: Authorization value: JWT TOKEN


#### What are the relevant pivotal tracker stories?
[#162339299](https://www.pivotaltracker.com/story/show/162339299)

